### PR TITLE
Refactor output of toolbox:tree command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 ## Pagetree
 
-Determine uids of all children in the pagetree of a given site identifier or root uid:
+Determine uids of all children in the pagetree of a given root uid:
+
+```bash
+bin/typo3 toolbox:tree 123 [--table=pages] [--depth=10] [--separator=,]
+```
+
+A site identifier can be used instead of the root uid:
 
 ```bash
 bin/typo3 toolbox:tree my-site-identifier
-bin/typo3 toolbox:tree 123
 ```
 
 ## Categorytree


### PR DESCRIPTION
It's only outputting the actual result now. In case you're interested in info texts, use --verbose. To have a different separator for the result list, use --separator

Resolves: #4