### PR TITLE
Compatibility TYPO3 14

### DIFF
--- a/Classes/Command/CopyCommand.php
+++ b/Classes/Command/CopyCommand.php
@@ -2,14 +2,11 @@
 
 namespace Kitzberger\CliToolbox\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class CopyCommand extends AbstractCommand
@@ -103,10 +100,11 @@ class CopyCommand extends AbstractCommand
         if ($this->io->confirm('Continue?', true)) {
             // Prevent hiding and prepending "Copy of" to copied records
             $GLOBALS['BE_USER']->uc['neverHideAtCopy'] = true;
+            // Set recursive copy depth on the BE_USER
+            $GLOBALS['BE_USER']->uc['copyLevels'] = self::DEPTH;
 
             // Perform operation
             $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-            $dataHandler->copyTree = self::DEPTH;
             $dataHandler->bypassAccessCheckForRecords = true;
             $dataHandler->start([], $cmd, $GLOBALS['BE_USER']);
             $dataHandler->process_cmdmap();

--- a/Classes/Command/CopyCommand.php
+++ b/Classes/Command/CopyCommand.php
@@ -101,9 +101,8 @@ class CopyCommand extends AbstractCommand
         }
 
         if ($this->io->confirm('Continue?', true)) {
-            // Make sure result is pretty ;-)
-            ExtensionManagementUtility::addPageTSConfig('TCEMAIN.table.' . $table . '.disableHideAtCopy = 1');
-            ExtensionManagementUtility::addPageTSConfig('TCEMAIN.table.' . $table . '.disablePrependAtCopy = 1');
+            // Prevent hiding and prepending "Copy of" to copied records
+            $GLOBALS['BE_USER']->uc['neverHideAtCopy'] = true;
 
             // Perform operation
             $dataHandler = GeneralUtility::makeInstance(DataHandler::class);

--- a/Classes/Command/CopyCommand.php
+++ b/Classes/Command/CopyCommand.php
@@ -48,13 +48,6 @@ class CopyCommand extends AbstractCommand
         );
 
         $this->addOption(
-            'be-user',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            'uid of be_user that performs this operation',
-        );
-
-        $this->addOption(
             'allowed-tables',
             null,
             InputOption::VALUE_OPTIONAL,
@@ -82,18 +75,6 @@ class CopyCommand extends AbstractCommand
         if (empty($source) || empty($target)) {
             $this->outputLine('<error>Please specify source and target!</>');
             return self::FAILURE;
-        }
-
-        $beUserOverride = $input->getOption('be-user');
-        if ($beUserOverride) {
-            $beUser = BackendUtility::getRecord('be_users', $beUserOverride);
-            if ($beUser) {
-                $GLOBALS['BE_USER']->user = $beUser;
-                $GLOBALS['BE_USER']->username = $beUser['username'];
-            } else {
-                $output->writeln('<error>No user found with uid ' . $beUserOverride . '</>');
-                return self::FAILURE;
-            }
         }
 
         $this->outputLine('memory_limit: ' . ini_get('memory_limit') . '</>');

--- a/Classes/Command/CopyCommand.php
+++ b/Classes/Command/CopyCommand.php
@@ -48,14 +48,6 @@ class CopyCommand extends AbstractCommand
         );
 
         $this->addOption(
-            'allowed-tables',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            'Allowed DB table?',
-            '*'
-        );
-
-        $this->addOption(
             'memory-limit',
             null,
             InputOption::VALUE_OPTIONAL,
@@ -70,7 +62,6 @@ class CopyCommand extends AbstractCommand
         $table = $input->getOption('table');
         $source = $input->getOption('source');
         $target = $input->getOption('target');
-        $allowedTables = $input->getOption('allowed-tables');
 
         if (empty($source) || empty($target)) {
             $this->outputLine('<error>Please specify source and target!</>');
@@ -107,9 +98,6 @@ class CopyCommand extends AbstractCommand
 
         if ($output->isVerbose()) {
             $this->outputLine(print_r($cmd, true));
-            if ($allowedTables !== '*') {
-                $this->outputLine('Allowed tables: ' . $allowedTables . '</>');
-            }
         }
 
         if ($this->io->confirm('Continue?', true)) {
@@ -121,7 +109,6 @@ class CopyCommand extends AbstractCommand
             $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
             $dataHandler->copyTree = self::DEPTH;
             $dataHandler->bypassAccessCheckForRecords = true;
-            $dataHandler->copyWhichTables = $allowedTables;
             $dataHandler->start([], $cmd, $GLOBALS['BE_USER']);
             $dataHandler->process_cmdmap();
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [TYPO3 datahandler](https://docs.typo3.org/typo3cms/CoreApiReference/ApiOver
 
 ```bash
 # Copy tt_content:123 to page:234
-bin/typo3 toolbox:copy --table=tt_content --source=123 --target=234 [--be-user=1] [--memory-limit=512M]
+bin/typo3 toolbox:copy --table=tt_content --source=123 --target=234 [--memory-limit=512M]
 
 # Copy tt_content:123 right behind tt_content:-234
 bin/typo3 toolbox:copy --table=tt_content --source=123 --target=-234

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["GPL-2.0+"],
     "keywords": ["TYPO3 CMS"],
     "require": {
-        "typo3/cms-core": "^10.4 || ^11.5 || ^12.4 || ^13.4"
+        "typo3/cms-core": "^10.4 || ^11.5 || ^12.4 || ^13.4 || ^14.3"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '4.2.6',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-13.4.99',
+            'typo3' => '10.4.0-14.3.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
:heavy_check_mark: `bin/typo3 toolbox:tree`
:heavy_check_mark: `bin/typo3 toolbox:find`
:heavy_check_mark: `bin/typo3 toolbox:delete`
:heavy_check_mark: `bin/typo3 toolbox:copy`
:heavy_check_mark: `bin/typo3 toolbox:move`
:heavy_check_mark: `bin/typo3 toolbox:move-fal-folder`

See:
* https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101799-ExtensionManagementUtilityaddPageTSConfig.html
* https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-107856-DataHandlerRemoveInternalPropertyCopyWhichTablesandPropertiesNeverHideAtCopyandCopyTree.html

Resolves: #10